### PR TITLE
remove unnecessary button tags for keyboard accessibility

### DIFF
--- a/layouts/partials/page_numbers.html
+++ b/layouts/partials/page_numbers.html
@@ -18,7 +18,7 @@
   {{ if $.Paginator.HasPrev }}
   <a href="{{ $.Paginator.Prev.URL }}">
     <li class="block-button-secondary">
-      <button>Previous</button>
+      Previous
     </li>
   </a>
   {{ end }}
@@ -27,7 +27,7 @@
   {{ if $.Paginator.HasNext }}
   <a href="{{ $.Paginator.Next.URL }}">
     <li class="block-button-secondary">
-      <button>Next</button>
+      Next
     </li>
   </a>
   {{ end }}

--- a/layouts/partials/top_nav.html
+++ b/layouts/partials/top_nav.html
@@ -30,35 +30,35 @@
           <div class="flex space-x-4 text-sm h-full items-center">
             <a href="https://boot.dev/tracks/backend"
               class="text-gray-300 hover:bg-gray-700 hover:text-white px-3 py-2 rounded">
-              <button>Courses</button>
+              Courses
             </a>
 
             <a href="https://boot.dev/pricing"
               class="text-gray-300 hover:bg-gray-700 hover:text-white px-3 py-2 rounded">
-              <button>Pricing</button>
+              Pricing
             </a>
 
             <a href="https://boot.dev/leaderboard"
               class="text-gray-300 hover:bg-gray-700 hover:text-white px-3 py-2 rounded">
-              <button>Leaderboard</button>
+              Leaderboard
             </a>
 
             <a href="https://boot.dev/community"
               class="text-gray-300 hover:bg-gray-700 hover:text-white px-3 py-2 rounded">
-              <button>Community</button>
+              Community
             </a>
 
             <a href="https://www.backendbanter.fm/"
               class="text-gray-300 hover:bg-gray-700 hover:text-white px-3 py-2 rounded">
-              <button>Podcast</button>
+              Podcast
             </a>
 
             <a href="/" class="text-gray-300 hover:bg-gray-700 hover:text-white px-3 py-2 rounded">
-              <button>Blog</button>
+              Blog
             </a>
 
             <a href="https://boot.dev" class="block-button-secondary">
-              <button>Sign In</button>
+              Sign In
             </a>
           </div>
         </div>
@@ -70,37 +70,37 @@
     <div class="px-2 pt-2 pb-3 space-y-1">
       <a href="https://boot.dev" class="bg-gray-900 text-white block px-3 py-2 rounded-md text-base font-medium"
         aria-current="page">
-        <button>Sign In</button>
+        Sign In
       </a>
 
       <a href="https://boot.dev/tracks/backend"
         class="text-gray-300 hover:bg-gray-700 hover:text-white block px-3 py-2 rounded-md text-base font-medium">
-        <button>Courses</button>
+        Courses
       </a>
 
       <a href="https://boot.dev/pricing"
         class="text-gray-300 hover:bg-gray-700 hover:text-white block px-3 py-2 rounded-md text-base font-medium">
-        <button>Pricing</button>
+        Pricing
       </a>
 
       <a href="https://boot.dev/leaderboard"
         class="text-gray-300 hover:bg-gray-700 hover:text-white block px-3 py-2 rounded-md text-base font-medium">
-        <button>Leaderboard</button>
+        Leaderboard
       </a>
 
       <a href="https://boot.dev/community"
         class="text-gray-300 hover:bg-gray-700 hover:text-white block px-3 py-2 rounded-md text-base font-medium">
-        <button>Community</button>
+        Community
       </a>
 
       <a href="/about/"
         class="text-gray-300 hover:bg-gray-700 hover:text-white block px-3 py-2 rounded-md text-base font-medium">
-        <button>About</button>
+        About
       </a>
 
       <a href="/"
         class="text-gray-300 hover:bg-gray-700 hover:text-white block px-3 py-2 rounded-md text-base font-medium">
-        <button>Blog</button>
+        Blog
       </a>
     </div>
   </div>

--- a/layouts/shortcodes/cta1.html
+++ b/layouts/shortcodes/cta1.html
@@ -15,7 +15,7 @@
   </div>
   <div class="flex justify-center">
     <a href="https://boot.dev" class="block-button-primary">
-      <button>Start the Back-end Career Path</button>
+      Start the Back-end Career Path
     </a>
   </div>
 </div>

--- a/layouts/shortcodes/cta2.html
+++ b/layouts/shortcodes/cta2.html
@@ -10,7 +10,7 @@
   </div>
   <div class="flex justify-center">
     <a href="https://boot.dev" class="block-button-primary">
-      <button>Start the Back-end Career Path</button>
+      Start the Back-end Career Path
     </a>
   </div>
 </div>

--- a/layouts/shortcodes/cta3.html
+++ b/layouts/shortcodes/cta3.html
@@ -5,7 +5,7 @@
   </p>
   <div class="flex justify-center">
     <a href="https://boot.dev" class="block-button-primary">
-      <button>Learn Computer Science for Back-end</button>
+      Learn Computer Science for Back-end
     </a>
   </div>
 </div>


### PR DESCRIPTION
There are several places where \<button\> tags are nested inside \<a\> tags - and these buttons have no classes assigned to them.

This nesting makes it necessary to hit Tab twice instead of once to move to the next button. This is especially annoying in the main menu of the website.

I tested the result on Chromium and Firefox - everything seems to be still functional and I have noticed no stylistic changes. The only styling of \<button\> tags that I've found is in "tail-out.css" file and seems to contain only resets.

**I have not tested on Safari!**

Alternative: If these button tags are necessary after all because of some functionality that I missed, then I recommend adding tabindex="-1" to all these buttons to make them non-reachable by keyboard.