### PR TITLE
made screen reader read header before link symbol

### DIFF
--- a/assets/css/tail-out.css
+++ b/assets/css/tail-out.css
@@ -719,6 +719,10 @@ video {
   z-index: 50;
 }
 
+.order-first {
+  order: -9999;
+}
+
 .col-span-1 {
   grid-column: span 1 / span 1;
 }
@@ -752,11 +756,6 @@ video {
 .mx-auto {
   margin-left: auto;
   margin-right: auto;
-}
-
-.my-1 {
-  margin-top: 0.25rem;
-  margin-bottom: 0.25rem;
 }
 
 .mb-4 {
@@ -797,6 +796,10 @@ video {
 
 .block {
   display: block;
+}
+
+.inline-block {
+  display: inline-block;
 }
 
 .inline {
@@ -871,10 +874,6 @@ video {
   cursor: pointer;
 }
 
-.list-disc {
-  list-style-type: disc;
-}
-
 .grid-cols-2 {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
@@ -883,8 +882,16 @@ video {
   flex-direction: row;
 }
 
+.flex-row-reverse {
+  flex-direction: row-reverse;
+}
+
 .flex-col {
   flex-direction: column;
+}
+
+.flex-col-reverse {
+  flex-direction: column-reverse;
 }
 
 .flex-wrap {
@@ -923,10 +930,6 @@ video {
   margin-bottom: calc(0.25rem * var(--tw-space-y-reverse));
 }
 
-.overflow-auto {
-  overflow: auto;
-}
-
 .overflow-visible {
   overflow: visible;
 }
@@ -949,10 +952,6 @@ video {
 
 .border-t-2 {
   border-top-width: 2px;
-}
-
-.border-r {
-  border-right-width: 1px;
 }
 
 .border-b {
@@ -1002,24 +1001,8 @@ video {
   padding: 1rem;
 }
 
-.p-6 {
-  padding: 1.5rem;
-}
-
 .p-2 {
   padding: 0.5rem;
-}
-
-.p-1 {
-  padding: 0.25rem;
-}
-
-.p-0\.5 {
-  padding: 0.125rem;
-}
-
-.p-0 {
-  padding: 0px;
 }
 
 .py-4 {
@@ -1047,11 +1030,6 @@ video {
   padding-right: 0.75rem;
 }
 
-.py-1 {
-  padding-top: 0.25rem;
-  padding-bottom: 0.25rem;
-}
-
 .pt-2 {
   padding-top: 0.5rem;
 }
@@ -1062,6 +1040,14 @@ video {
 
 .text-center {
   text-align: center;
+}
+
+.align-baseline {
+  vertical-align: baseline;
+}
+
+.align-bottom {
+  vertical-align: bottom;
 }
 
 .text-4xl {
@@ -1105,10 +1091,6 @@ video {
 
 .font-medium {
   font-weight: 500;
-}
-
-.italic {
-  font-style: italic;
 }
 
 .leading-6 {
@@ -1284,10 +1266,6 @@ video {
 }
 
 @media (min-width: 1024px) {
-  .lg\:block {
-    display: block;
-  }
-
   .lg\:px-8 {
     padding-left: 2rem;
     padding-right: 2rem;

--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -1,6 +1,6 @@
-<h{{ .Level }} class="anchor group" id="{{ .Anchor | safeURL }}">
-  {{- if and (ge .Level 1) (le .Level 6) }}{{" " -}}
-  <a href="#{{ .Anchor | safeURL }}">🔗</a>
-  {{- end -}}
+<h{{ .Level }} class="flex anchor group" id="{{ .Anchor | safeURL }}">
   <span> {{ .Text | safeHTML }}</span>
+  {{- if and (ge .Level 1) (le .Level 6) }}{{" " -}}
+  <a class="mr-2 order-first" href="#{{ .Anchor | safeURL }}">🔗</a>
+  {{- end -}}
 </h{{ .Level }}>


### PR DESCRIPTION
Before this PR, screen readers would read headers in the blog like this
"Link, Link Symbol - actual heading text"

Now, after reversing the order of these two elements in the HTML. It reads headings like this
"actual heading text - Link Symbol"

This makes navigating by header for screen readers much quicker.

It might be worth leaving a comment or something to explain why the elements are reversed in `render-heading` otherwise people might change it in the future. Thoughts?