### PR TITLE
Remove incorrect backticks when marshalling a User

### DIFF
--- a/content/golang/json-golang.md
+++ b/content/golang/json-golang.md
@@ -33,11 +33,11 @@ func Marshal(v interface{}) ([]byte, error)
 As you can see, `Marshal()` takes a value as input, and returns the encoded JSON as a slice of bytes on success, or an `error` if something went wrong.
 
 ```go
-dat, _ := json.Marshal(`User{
+dat, _ := json.Marshal(User{
     FirstName: "Lane",
     BirthYear: 1990,
     Email:     "example@gmail.com",
-}`)
+})
 fmt.Println(string(dat))
 
 // prints:


### PR DESCRIPTION
json.Marshal was being called with a string instead of an actual User instance.