### PR TITLE
Fix inaccurate "As mentioned above" assertion

### DIFF
--- a/content/golang/json-golang.md
+++ b/content/golang/json-golang.md
@@ -193,7 +193,7 @@ type User struct {
 
 ### Tag Options - Ignore field
 
-As mentioned above, non-exported (lowercase) fields are ignored by the marshaler. If you want to ignore additional fields you can use the `-` tag.
+Non-exported (lowercase) fields are ignored by the marshaler. If you want to ignore additional fields you can use the `-` tag.
 
 ```go
 type User struct {


### PR DESCRIPTION
At some point the article says "As mentioned above, non-exported (lowercase) fields are ignored by the marshaler.". But there is no such previous mention (nor any later mention).