### PR TITLE
non-exported --> unexported

### DIFF
--- a/content/golang/json-golang.md
+++ b/content/golang/json-golang.md
@@ -193,7 +193,7 @@ type User struct {
 
 ### Tag Options - Ignore field
 
-As mentioned above, non-exported (lowercase) fields are ignored by the marshaler. If you want to ignore additional fields you can use the `-` tag.
+[Unexported](https://go.dev/tour/basics/3) (lowercase) fields are ignored by the marshaler. If you want to ignore additional fields you can use the `-` tag.
 
 ```go
 type User struct {


### PR DESCRIPTION
I noticed this "non-exported" term being used. It seems like the convention is to use "unexported" for non-exported fields.
